### PR TITLE
fix isuptospeed inconsistency

### DIFF
--- a/RapidReact/src/main/java/frc/robot/Robot.java
+++ b/RapidReact/src/main/java/frc/robot/Robot.java
@@ -265,10 +265,11 @@ public class Robot extends TimedRobot {
   @Override
   public void teleopPeriodic() {
     if(shooterSubsystem.isShooting()){
-      if(shooterSubsystem.isUpToSpeed()){
+      if (shooterSubsystem.isUpToSpeed()) {
         intakeSubsystem.ballManagementForward();
       }
-      else{
+      else
+      {
         intakeSubsystem.stopBallManagement();
       }
     }
@@ -338,6 +339,37 @@ public class Robot extends TimedRobot {
     if (config.enableShooterSubsystem) {
       buttons.lowShoot.whenPressed(shooterSubsystem::shootLow);
       buttons.lowShoot.whenReleased(shooterSubsystem::stopShoot);
+
+      buttons.hubShoot.whenPressed(() -> {
+        shooterSubsystem.shootTop();
+      });
+      buttons.hubShoot.whenReleased(() -> {
+        shooterSubsystem.stopShoot();
+        if (config.enableIntakeSubsystem) {
+          intakeSubsystem.stopBallManagement();
+        }
+      });
+    
+      buttons.tarmacShootOrToggleElevator.whenPressed(
+        () -> {
+          if (config.enableClimberSubsystem && climberSubsystem.isClimberEnabled()) {
+            climberSubsystem.elevatorToggle();
+          } else {
+            shooterSubsystem.shootTarmac();
+            //lmao
+            if (drivetrainSubsystem != null) {
+              drivetrainSubsystem.orient();
+            }
+          }
+        }
+      );
+      buttons.tarmacShootOrToggleElevator.whenReleased(
+        () -> {
+          if (config.enableShooterSubsystem) {
+            shooterSubsystem.stopShoot();
+          }
+        }
+      );
     }
 
     //Climber buttons
@@ -364,17 +396,17 @@ public class Robot extends TimedRobot {
           }
         )
         .whenReleased(() -> driverClimbEnabledPressed = false);
-
+    
       buttons.elevatorExtend.whenPressed(climberSubsystem::manualElevatorExtend);
       buttons.elevatorExtend.whenReleased(climberSubsystem::elevatorStop);
-
+    
       buttons.elevatorRetract.whenPressed(climberSubsystem::manualElevatorRetract);
       buttons.elevatorRetract.whenReleased(climberSubsystem::elevatorStop);
       
       buttons.climbAuto.whenPressed(climberSubsystem::autoClimb);
       buttons.climbAuto.whenReleased(climberSubsystem::autoClimbReleased);
       buttons.resetClimbStuff.whenPressed(climberSubsystem::resetClimbStuff);
-
+    
       buttons.autoClimbStopLeft.whenPressed(
         () -> {
           autoClimbStopLeftPressed = true;
@@ -395,48 +427,6 @@ public class Robot extends TimedRobot {
         }
       )
       .whenReleased(() -> autoClimbStopRightPressed = false);
-
-
-    }
-    
-    //Shooter BUttons and Climber Buttons
-    if (config.enableShooterSubsystem)
-    {
-
-      buttons.hubShoot.whenPressed(() -> {
-        shooterSubsystem.shootTop();
-        if (config.enableIntakeSubsystem) {
-          intakeSubsystem.ballManagementForward();
-        }
-      });
-      buttons.hubShoot.whenReleased(() -> {
-        shooterSubsystem.stopShoot();
-        if (config.enableIntakeSubsystem) {
-          intakeSubsystem.stopBallManagement();
-        }
-      });
-    
-      buttons.tarmacShootOrToggleElevator.whenPressed(
-        () -> {
-          if (config.enableClimberSubsystem && climberSubsystem.isClimberEnabled()) {
-            climberSubsystem.elevatorToggle();
-          } else {
-            shooterSubsystem.shootTarmac();
-
-            if (drivetrainSubsystem != null) {
-              //lmao
-              drivetrainSubsystem.orient();
-            }
-          }
-        }
-      );
-      buttons.tarmacShootOrToggleElevator.whenReleased(
-        () -> {
-          if (config.enableShooterSubsystem) {
-            shooterSubsystem.stopShoot();
-          }
-        }
-      );
     }
   }
 }

--- a/RapidReact/src/main/java/frc/robot/subsystem/IntakeSubsystem.java
+++ b/RapidReact/src/main/java/frc/robot/subsystem/IntakeSubsystem.java
@@ -28,6 +28,7 @@ public class IntakeSubsystem extends BitBucketsSubsystem {
     config.intake.defaultIntakeAutoExtend
   );
   private final Loggable<String> intakeState = BucketLog.loggable(Put.STRING, "intake/intakeState");
+  public final Loggable<String> bmsState = BucketLog.loggable(Put.STRING, "intake/bmsState");
 
   public IntakeSubsystem(Config config) {
     super(config);
@@ -67,14 +68,14 @@ public class IntakeSubsystem extends BitBucketsSubsystem {
       intakeSolenoid.set(Value.kForward);
     }
     intake.set(ControlMode.PercentOutput, percentOutput.currentValue());
-    ballManagement.set(ControlMode.PercentOutput, percentOutput.currentValue());
     intakeState.log("intaking");
+    ballManagementForward();
   }
 
   public void spinBackward() {
     intake.set(ControlMode.PercentOutput, -percentOutput.currentValue());
-    ballManagement.set(ControlMode.PercentOutput, -percentOutput.currentValue());
     intakeState.log("outtaking");
+    ballManagementBackward();
   }
 
   public void stopSpin() {
@@ -82,8 +83,8 @@ public class IntakeSubsystem extends BitBucketsSubsystem {
       intakeSolenoid.set(Value.kReverse);
     }
     intake.set(ControlMode.PercentOutput, 0);
-    ballManagement.set(ControlMode.PercentOutput, 0);
     intakeState.log("stopped");
+    stopBallManagement();
   }
 
   //toggles turning the intake on or off
@@ -103,9 +104,17 @@ public class IntakeSubsystem extends BitBucketsSubsystem {
 
   public void ballManagementForward() {
     ballManagement.set(ControlMode.PercentOutput, percentOutput.currentValue());
+    bmsState.log(LogLevel.GENERAL, "bms intaking");
+  }
+
+  public void ballManagementBackward() {
+    ballManagement.set(ControlMode.PercentOutput, -percentOutput.currentValue());
+    bmsState.log(LogLevel.GENERAL, "bms outtaking");
   }
 
   public void stopBallManagement() {
     ballManagement.set(ControlMode.PercentOutput, 0);
+    bmsState.log(LogLevel.GENERAL, "bms stopped");
   }
+
 }

--- a/RapidReact/src/main/java/frc/robot/subsystem/ShooterSubsystem.java
+++ b/RapidReact/src/main/java/frc/robot/subsystem/ShooterSubsystem.java
@@ -9,8 +9,10 @@ import com.revrobotics.REVPhysicsSim;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.simulation.EncoderSim;
 import edu.wpi.first.wpilibj.simulation.FlywheelSim;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Robot;
 import frc.robot.config.Config;
 import frc.robot.log.*;
@@ -69,7 +71,7 @@ public class ShooterSubsystem extends BitBucketsSubsystem {
 
     shooterTop.set(0);
     shooterBottom.set(0);
-    feeder.set(ControlMode.PercentOutput, 0);
+    turnOffFeeders();
   }
 
   public void shootTop() {
@@ -134,7 +136,7 @@ public class ShooterSubsystem extends BitBucketsSubsystem {
 
   public boolean isUpToSpeed() {
     return (
-      true ||
+      // true ||
       motorIsInSpeedDeadband(shooterTop, topSpeed.currentValue()) &&
       motorIsInSpeedDeadband(shooterBottom, bottomSpeed.currentValue())
     );
@@ -142,10 +144,18 @@ public class ShooterSubsystem extends BitBucketsSubsystem {
 
   @Override
   public void periodic() {
-    if (shooterState != ShooterState.STOPPED && isUpToSpeed()) {
-      turnOnFeeders();
-    } 
-  }
+    if (isShooting())
+    {
+      if (isUpToSpeed())
+      {
+        turnOnFeeders();
+      }
+      else
+      {
+        turnOffFeeders();
+      }
+    }
+  } 
 
   @Override
   public void simulationPeriodic() {


### PR DESCRIPTION
the feeder would turn on as soon as the motors hit uptospeed, and would only turn off once the button was released -- if the motor went beyond the deadband they would continue to run

the BMS however would turn off as soon as the shooters weren't in the deadband range anymore; this is why it would run for half a second and then stop.

this PR mirrors the BMS functionality in the feeder subsystem and makes it uniform

Addresses #113 